### PR TITLE
update message-schema version, fix unit tests and fix prettier CI

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -16,7 +16,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
           # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
           persist-credentials: false
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "@music-os/extraction-worker",
+  "name": "@neume-network/extraction-worker",
   "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@music-os/extraction-worker",
+      "name": "@neume-network/extraction-worker",
       "version": "0.0.3",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@music-os/message-schema": "0.0.1",
+        "@neume-network/message-schema": "0.2.0",
         "ajv": "8.11.0",
         "better-queue": "3.8.10",
         "cross-fetch": "3.1.5",
@@ -389,10 +389,10 @@
         "@ethersproject/strings": "^5.6.0"
       }
     },
-    "node_modules/@music-os/message-schema": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@music-os/message-schema/-/message-schema-0.0.1.tgz",
-      "integrity": "sha512-svQ5RGV+zBcrWEa+/XLofaknr+ZxI/0XfOb4hKi/OtTIp/DZaiddj8CglBpNZw+C8LlGiplioLgEwvRLgmV/sA=="
+    "node_modules/@neume-network/message-schema": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@neume-network/message-schema/-/message-schema-0.2.0.tgz",
+      "integrity": "sha512-v0nmhIm08XlwWRmX43KSRf/c3kM4ZvX93GUq7zqltNpYuROh5JMy+v52pAdRMF9VithZ+memw+e8U94DtOUq2A=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4326,10 +4326,10 @@
         "@ethersproject/strings": "^5.6.0"
       }
     },
-    "@music-os/message-schema": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@music-os/message-schema/-/message-schema-0.0.1.tgz",
-      "integrity": "sha512-svQ5RGV+zBcrWEa+/XLofaknr+ZxI/0XfOb4hKi/OtTIp/DZaiddj8CglBpNZw+C8LlGiplioLgEwvRLgmV/sA=="
+    "@neume-network/message-schema": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@neume-network/message-schema/-/message-schema-0.2.0.tgz",
+      "integrity": "sha512-v0nmhIm08XlwWRmX43KSRf/c3kM4ZvX93GUq7zqltNpYuROh5JMy+v52pAdRMF9VithZ+memw+e8U94DtOUq2A=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prettier": "2.6.2"
   },
   "dependencies": {
-    "@neume-network/message-schema": "0.0.1",
+    "@neume-network/message-schema": "0.2.0",
     "ajv": "8.11.0",
     "better-queue": "3.8.10",
     "cross-fetch": "3.1.5",

--- a/test/api_test.mjs
+++ b/test/api_test.mjs
@@ -12,6 +12,7 @@ test("sending a graphql message", (t) => {
   const message = {
     type: "graphql",
     version: messages.version,
+    commissioner: "soundxyz",
     options: {
       url: "https://example.com",
       body: JSON.stringify({
@@ -196,6 +197,7 @@ test("validating schema `type` prop", (t) => {
     options: {
       url: env.RPC_HTTP_HOST,
     },
+    commissioner: "soundxyz",
     version: messages.version,
     type: "json-rpc",
     method: "eth_getBlockByNumber",
@@ -208,6 +210,7 @@ test("validating schema `type` prop", (t) => {
 test("validating http job schema", (t) => {
   const message = {
     type: "https",
+    commissioner: "soundxyz",
     version: "0.0.1",
     options: {
       url: "https://example.com",

--- a/test/start_test.mjs
+++ b/test/start_test.mjs
@@ -22,6 +22,7 @@ test("sending throwing job to worker", async (t) => {
     options: {
       url: env.RPC_HTTP_HOST,
     },
+    commissioner: "soundxyz",
     version: messages.version,
     type: "json-rpc",
     method: "willmakeworkerthrow",
@@ -57,6 +58,7 @@ test("running script in worker queue", async (t) => {
     options: {
       url: env.RPC_HTTP_HOST,
     },
+    commissioner: "soundxyz",
     version: messages.version,
     type: "json-rpc",
     method: "eth_getTransactionReceipt",


### PR DESCRIPTION
There is no release of @neume-network/message-schema corresponding to 0.0.1.

Check the versions tab here for more details. https://www.npmjs.com/package/@neume-network/message-schema