### PR TITLE
Return message object from panic function

### DIFF
--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -16,7 +16,7 @@ export function panic(taskId, error, stats) {
   if (error && error instanceof Error) {
     error = error.toString();
   } else if (error && error instanceof Object) {
-    message = { error: error.error };
+    message = { ...error };
     error = JSON.stringify(error);
   }
   log(


### PR DESCRIPTION
Fixes #34 

Due to the issue #34 the upgraded lifecycle was not able to close properly. The error was not being propagated to the strategy. This PR should fix that issue.

We'll also need to publish extraction-worker after this fix.