### PR TITLE
try to parse all requests as json

### DIFF
--- a/src/api.mjs
+++ b/src/api.mjs
@@ -1,6 +1,5 @@
 // @format
 import Ajv from "ajv";
-import fetch from "cross-fetch";
 import {
   exit as exitMsg,
   https,
@@ -13,6 +12,7 @@ import logger from "./logger.mjs";
 import { ValidationError, NotImplementedError } from "./errors.mjs";
 import { translate } from "./eth.mjs";
 import { endpointStore } from "./endpoint_store.mjs";
+import { request } from "./request.mjs";
 
 const log = logger("api");
 const ajv = new Ajv();
@@ -39,48 +39,6 @@ function validate(value) {
   }
 
   return true;
-}
-
-export async function request(url, method, body, headers, signal) {
-  let options = {
-    method,
-  };
-
-  if (body) {
-    options.body = body;
-  }
-  if (headers) {
-    options.headers = headers;
-  }
-  if (signal) {
-    options.signal = signal;
-  }
-
-  // NOTE: We let `fetch` throw. Error must be caught on `request` user level.
-  const results = await fetch(url, options);
-  const answer = await results.text();
-
-  if (results.status >= 400) {
-    throw new Error(
-      `Request to url "${url}" with method "${method}" and body "${JSON.stringify(
-        body
-      )}" unsuccessful with status: ${results.status} and answer: "${answer}"`
-    );
-  }
-
-  if (results.headers.get("Content-Type")?.toLowerCase().includes("json")) {
-    let data;
-    try {
-      data = JSON.parse(answer);
-    } catch (err) {
-      throw new Error(
-        `Encountered error when trying to parse JSON body result: "${answer}", error: "${err.toString()}"`
-      );
-    }
-    return data;
-  }
-
-  return answer;
 }
 
 // NOTE: `AbortSignal.timeout` isn't yet supported:

--- a/src/request.mjs
+++ b/src/request.mjs
@@ -1,0 +1,41 @@
+import fetch from "cross-fetch";
+
+export async function request(url, method, body, headers, signal) {
+  let options = {
+    method,
+  };
+
+  if (body) {
+    options.body = body;
+  }
+  if (headers) {
+    options.headers = headers;
+  }
+  if (signal) {
+    options.signal = signal;
+  }
+
+  // NOTE: We let `fetch` throw. Error must be caught on `request` user level.
+  const results = await fetch(url, options);
+  const answer = await results.text();
+
+  if (results.status >= 400) {
+    throw new Error(
+      `Request to url "${url}" with method "${method}" and body "${JSON.stringify(
+        body
+      )}" unsuccessful with status: ${results.status} and answer: "${answer}"`
+    );
+  }
+
+  try {
+    return JSON.parse(answer);
+  } catch (err) {
+    if (results.headers.get("Content-Type")?.toLowerCase().includes("json")) {
+      throw new Error(
+        `Encountered error when trying to parse JSON body result: "${answer}", error: "${err.toString()}"`
+      );
+    }
+
+    return answer;
+  }
+}

--- a/test/api_test.mjs
+++ b/test/api_test.mjs
@@ -5,7 +5,7 @@ import test from "ava";
 import esmock from "esmock";
 import createWorker from "expressively-mocked-fetch";
 
-import { request, messages, AbortSignal } from "../src/api.mjs";
+import { messages, AbortSignal } from "../src/api.mjs";
 import { ValidationError } from "../src/errors.mjs";
 
 test("sending a json-rpc request that times out", async (t) => {

--- a/test/request_test.mjs
+++ b/test/request_test.mjs
@@ -1,0 +1,66 @@
+import test from "ava";
+import createWorker from "expressively-mocked-fetch";
+
+import { request } from "../src/request.mjs";
+
+test("should be able to parse if content-type is json and body is parsable", async (t) => {
+  const worker = await createWorker(
+    `
+    app.get('/', async (req, res) => {
+      res.status(200).set('Content-Type', 'application/json').json({hello: "world"});
+    });
+  `
+  );
+
+  const res = await request(`http://localhost:${worker.port}`, "GET");
+  t.deepEqual(res, { hello: "world" });
+  worker.process.terminate();
+});
+
+test("should be able to parse if content-type is undefined and body is parsable", async (t) => {
+  const worker = await createWorker(
+    `
+    app.get('/', async (req, res) => {
+      res.status(200).json({hello: "world"});
+    });
+  `
+  );
+
+  const res = await request(`http://localhost:${worker.port}`, "GET");
+
+  t.deepEqual(res, { hello: "world" });
+  worker.process.terminate();
+});
+
+test("should not be able to parse if content-type is json and body is unparsable", async (t) => {
+  const worker = await createWorker(
+    `
+    app.get('/', async (req, res) => {
+      res.status(200).set('Content-Type', 'application/json').send('hello');
+    });
+  `
+  );
+
+  await t.throwsAsync(
+    async () => request(`http://localhost:${worker.port}`, "GET"),
+    {
+      message:
+        'Encountered error when trying to parse JSON body result: "hello", error: "SyntaxError: Unexpected token h in JSON at position 0"',
+    }
+  );
+  worker.process.terminate();
+});
+
+test("should return plaintext if content-type is undefined and body is not parsable", async (t) => {
+  const worker = await createWorker(
+    `
+    app.get('/', async (req, res) => {
+      res.status(200).send('hello');
+    });
+  `
+  );
+
+  const res = await request(`http://localhost:${worker.port}`, "GET");
+  t.is(res, "hello");
+  worker.process.terminate();
+});


### PR DESCRIPTION
Fixes #53 

Try to parse all requests as json and fallback to returning text if unparsable. In case the body is unparsable but content-type is json we throw an error. Also add tests for various cases.

Created a new file for `request` because I didn't want to add all the new test cases in `api_test.mjs` file. That file is already quite large.